### PR TITLE
move save button to plugin, only show it in preview

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -40,13 +40,43 @@ function initializeCodeByte(api) {
     },
   });
 
-  api.decorateCookedElement((elem) => {
-    const codebyteDivs = elem.querySelectorAll("div.d-codebyte");
-    codebyteDivs.forEach((div) => {
-      const snippet = div.textContent.trim();
-      div.innerHTML = `<iframe width="600" height="460" style="border: 0;" src="http://localhost:8000/codebyte-editor?code=${encodeURIComponent(snippet)}" ></iframe>`;
+  function renderCodebyteFrame(params = {}) {
+    const frame = document.createElement('iframe');
+
+    const urlParams = Object.keys(params).reduce((acc, key, i) => (
+      `${acc}${i === 0 ? '?' : '&'}${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`
+    ), '');
+
+    frame.src = `http://localhost:8000/codebyte-editor${urlParams}`;
+
+    Object.assign(frame.style, {
+      display: 'block',
+      height: '400px',
+      width: '100%',
+      maxWidth: '712px',
+      border: 0,
     });
 
+    return frame;
+  }
+
+  api.decorateCookedElement((elem) => {
+    elem.querySelectorAll("div.d-codebyte").forEach((div) => {
+      const codebyteFrame = renderCodebyteFrame({
+        code: div.textContent.trim()
+      });
+      div.innerHTML = '';
+      div.appendChild(codebyteFrame);
+
+      if (elem.classList.contains('d-editor-preview')) {
+        const saveButton = document.createElement('button');
+        saveButton.className = 'btn-primary';
+        saveButton.textContent = 'Save to post';
+        saveButton.style.marginTop = '24px';
+        saveButton.onclick = () => codebyteFrame.contentWindow.postMessage(null, '*');
+        div.appendChild(saveButton);
+      }
+    });
   });
 }
 


### PR DESCRIPTION
  
<!---
READ THIS: Please review the Pre-Review Checklist before seeking review! https://www.notion.so/codecademy/Development-Process-0e566d88c7734561b63f45313a9c40bd
-->

## Overview
the discourse plugin now handles all discourse-specific code (mostly the "save to post button"). That button is now hidden on authored topics and only visible when previewing topics.

### PR Checklist
- [x] Related to JIRA ticket: [REACH-691](https://codecademy.atlassian.net/browse/REACH-691)
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
companion to https://github.com/codecademy-engineering/static-sites/pull/646

### Testing Instructions
1. run discourse locally with [companion PR](https://github.com/codecademy-engineering/static-sites/pull/646)
2. make a new topic and add a codebyte
3. make sure a "save to post" button appears below the codebyte in the preview window and that it works
4. post the topic
5. go to the topic and see that the codebyte is there with no "save to post button"
6. edit the topic and see that the "save to post" button is back and that it works