### PR TITLE
Use Discourse's loadScript() to import 'js-base64' lib for URI encoding

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -1,4 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
+import loadScript from "discourse/lib/load-script";
 
 function initializeCodeByte(api) {
   api.onToolbarCreate((toolbar) => {
@@ -15,16 +16,16 @@ function initializeCodeByte(api) {
     };
 
     if (window.addEventListener) {
-      window.addEventListener("message", onMessage, false);        
+      window.addEventListener("message", onMessage, false);
     } 
     else if (window.attachEvent) {
-        window.attachEvent("onmessage", onMessage, false);
+      window.attachEvent("onmessage", onMessage, false);
     }
-    
+
     function onMessage(event) {
-        // Check sender origin to be trusted
-        // if (event.origin !== "http://example.com") return;
-        window.updateCodeByte(event.data);
+      // Check sender origin to be trusted
+      // if (event.origin !== "http://example.com") return;
+      window.updateCodeByte(event.data);
     }
 
   });
@@ -43,11 +44,8 @@ function initializeCodeByte(api) {
   function renderCodebyteFrame(params = {}) {
     const frame = document.createElement('iframe');
 
-    const urlParams = Object.keys(params).reduce((acc, key, i) => (
-      `${acc}${i === 0 ? '?' : '&'}${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`
-    ), '');
-
-    frame.src = `http://localhost:8000/codebyte-editor${urlParams}`;
+    const encodedURI = Base64.encodeURI(params.code);
+    frame.src = `http://localhost:8000/codebyte-editor?code=${encodedURI}`;
 
     Object.assign(frame.style, {
       display: 'block',
@@ -84,6 +82,12 @@ export default {
   name: "code-bytes",
 
   initialize() {
-    withPluginApi("0.8.31", initializeCodeByte);
-  }
+    withPluginApi("0.8.31", (api) => {
+      loadScript(
+        "https://cdn.jsdelivr.net/npm/js-base64@3.6.0/base64.min.js"
+      ).then(() => {
+        return initializeCodeByte(api);
+      });
+    });
+  },
 };

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,6 +10,10 @@ register_asset 'stylesheets/common/code-bytes.scss'
 register_asset 'stylesheets/desktop/code-bytes.scss', :desktop
 register_asset 'stylesheets/mobile/code-bytes.scss', :mobile
 
+extend_content_security_policy(
+  script_src: ['https://cdn.jsdelivr.net/npm/js-base64@3.6.0/base64.min.js']
+)
+
 enabled_site_setting :code_bytes_enabled
 
 PLUGIN_NAME ||= 'CodeByte'


### PR DESCRIPTION
## Overview
Discourse lib exports a [`loadScript function` (source)](https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/app/lib/load-script.js#L42) that can be used to [integrate third party scripts in our plugins.](https://meta.discourse.org/t/how-do-we-fire-scripts-after-topic-html-is-rendered-in-dom/114701/3.)


I went with using https://github.com/dankogai/js-base64, which has functions [`encodeURI` (source)](https://github.com/dankogai/js-base64/blob/375a99b0d85b0c03133924b2a1135d0ca2d11247/base64.js#L158-L162) which we'll use on the Discourse side, and [`decode` (source)](https://github.com/dankogai/js-base64/blob/375a99b0d85b0c03133924b2a1135d0ca2d11247/base64.js#L235-L240) which we will have to use on the iFrame client end.

### PR Checklist
- [x] Related to JIRA ticket: REACH-706
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change


### On Content Security Policy
I extended the default CSP by adding the [CDN link for js-base64](https://github.com/dankogai/js-base64#usage) in our `plugin.rb` file.

#### Why?

> **If your plugin integrates or depends on third-party JavaScripts**, you may extend the default CSP in plugin.rb with the extend_content_security_policy API. ([Doc](https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243#2-in-plugins))
> ```rb
> # plugin.rb
> extend_content_security_policy(
>   script_src: ['https://domain.com/script.js', 'https://your-cdn.com/'],
>   object_src: ['https://domain.com/flash-content']
> )
> ```

> **What is Content Security Policy?**
>  >Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement to distribution of malware.
>  >– Content Security Policy (CSP) - HTTP | MDN 67
> 
> [Discourse mitigates XSS attacks with CSP](https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243#what-is-content-security-policy), by allowing scripts only from trusted sources to load and execute. Discourse’s default policy employs a strict URL whitelist, and only allows sources that Discourse needs.

### Notes

#### Before
<img width="466" alt="before" src="https://user-images.githubusercontent.com/17210163/111795765-e0576900-889d-11eb-9924-4e9d7a6a0fb1.png">

#### After
<img width="466" alt="after" src="https://user-images.githubusercontent.com/17210163/111795776-e2b9c300-889d-11eb-8db7-177f684ad663.png">


### Testing Instructions
1. Run companion static sites PR https://github.com/codecademy-engineering/static-sites/pull/670
2. Test by writing code inside component, check network tab to see that the url is encoded a la Base64.
