### PR TITLE
lazily deregister event listeners

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -12,7 +12,9 @@ function initializeCodeByte(api) {
     });
 
     const onSaveResponse = (message) => {
-      if (message.data.codeBytesSaveResponse) {
+      if (toolbar.context.isDestroyed || toolbar.context.isDestroying) {
+        window.removeEventListener("message", onSaveResponse);
+      } else if (message.data.codeBytesSaveResponse) {
         toolbar.context.send("updateCodeByte", message.data.codeBytesSaveResponse);
       }
     };


### PR DESCRIPTION
  
<!---
READ THIS: Please review the Pre-Review Checklist before seeking review! https://www.notion.so/codecademy/Development-Process-0e566d88c7734561b63f45313a9c40bd
-->

## Overview
not sure if there's a good way to listen for toolbar destruction (there is an `api.onToolbarCreate` but not an `api.onToolbarDestroy` 🎉). Instead, we can check if the toolbar has been destroyed when we receive a message, and if so we can just deregister its listener.

### PR Checklist
- [x] Related to JIRA ticket: [REACH-707](https://codecademy.atlassian.net/browse/REACH-707)
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
pretty normal ember.js workaround, [detailed here](https://stackoverflow.com/questions/25141822/uncaught-error-assertion-failed-calling-set-on-destroyed-object)

### Testing Instructions
1. create a topic
2. click `cancel`
3. create a topic
4. add a codebyte
5. click `save to post`
6. ensure there are no console errors
