### PR TITLE
Wrap selected text in codebyte tags

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -25,27 +25,35 @@ function initializeCodeByte(api) {
   api.modifyClass("component:d-editor", {
     actions: {
       insertCodeByte() {
-        const exampleFormat = '[codebyte]\nhello world\n[/codebyte]'
+        let exampleFormat = '[codebyte]\nhello world\n[/codebyte]'
+        let startTag = '[codebyte]\n'
+        let endTag = '\n[/codebyte]'
         const lineValueSelection = this._getSelected("", {lineVal:true})
         const selection = this._getSelected()
-        const addBlockInline = lineValueSelection.lineVal.length === 0
+        const addBlockInSameline = lineValueSelection.lineVal.length === 0
         const isTextSelected = selection.value.length > 0
+        const isWholeLineSelected = lineValueSelection.lineVal === lineValueSelection.value
+        const isBeginningOfLineSelected = lineValueSelection.pre.trim() === ""
+        const newLineAfterSelection = selection.post[0]==='\n'
         if(isTextSelected){
-          if(addBlockInline || 
-            lineValueSelection.lineVal === lineValueSelection.value || 
-            lineValueSelection.pre.trim() === ""){
-            this.set('value',`${selection.pre}[codebyte]\n${selection.value}\n[/codebyte]${selection.post}`)
-          } else {
-            this.set('value',`${selection.pre}\n[codebyte]\n${selection.value}\n[/codebyte]${selection.post}`)
+          if(!(addBlockInSameline || isWholeLineSelected || isBeginningOfLineSelected)) {
+            startTag = '\n' + startTag
           }
+          if(!newLineAfterSelection) {
+            endTag = endTag + '\n'
+          }
+          this.set('value', `${selection.pre}${startTag}${selection.value}${endTag}${selection.post}`)
           return 
         }
         else {
-          if(addBlockInline){
-            this._insertText(exampleFormat)
-          } else {
-            this._insertText(`\n${exampleFormat}`)
+          console.log(addBlockInSameline, newLineAfterSelection)
+          if(!addBlockInSameline){
+            exampleFormat = '\n'+exampleFormat
           }
+          if(!newLineAfterSelection) {
+            exampleFormat = exampleFormat + '\n'
+          }
+          this._insertText(exampleFormat)
           return
         }
       },


### PR DESCRIPTION
  
<!---
READ THIS: Please review the Pre-Review Checklist before seeking review! https://www.notion.so/codecademy/Development-Process-0e566d88c7734561b63f45313a9c40bd
-->

## Overview
Selecting text and then pressing the codebyte button in the discourse editor toolbar now wraps the selected text in `codebyte` tags

### PR Checklist
- [x] Related to JIRA ticket: [REACH-656](https://codecademy.atlassian.net/browse/REACH-656)
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
Before
![before wrap](https://user-images.githubusercontent.com/22219812/112182045-54ae4700-8bd3-11eb-95ab-26afa1e5e6e5.gif)

After
![after wrap](https://user-images.githubusercontent.com/22219812/112182065-5841ce00-8bd3-11eb-9a40-7b2084f0db30.gif)

### Testing Instructions
1. Run Discourse locally
2. Type some text and select it
3. Click on the Codebyte button in the editor toolbar
4. Confirm the selected text is wrapped in `codebyte` tags
