### PR TITLE
Move loadscript inside renderCodebyteFrame

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -34,25 +34,29 @@ function initializeCodeByte(api) {
   });
 
   function renderCodebyteFrame(language = '', code = '') {
-    const frame = document.createElement('iframe');
+    return loadScript(
+      "https://cdn.jsdelivr.net/npm/js-base64@3.6.0/base64.min.js"
+    ).then(() => {
+      const frame = document.createElement('iframe');
 
-    const encodedURI = Base64.encodeURI(code);
-    frame.src = `http://localhost:8000/codebyte-editor?lang=${language}&code=${encodedURI}`;
+      const encodedURI = Base64.encodeURI(code);
+      frame.src = `http://localhost:8000/codebyte-editor?lang=${language}&code=${encodedURI}`;
 
-    Object.assign(frame.style, {
-      display: 'block',
-      height: '400px',
-      width: '100%',
-      maxWidth: '712px',
-      border: 0,
+      Object.assign(frame.style, {
+        display: 'block',
+        height: '400px',
+        width: '100%',
+        maxWidth: '712px',
+        border: 0,
+      });
+
+      return frame;
     });
-
-    return frame;
-  }
+  };
 
   api.decorateCookedElement((elem) => {
-    elem.querySelectorAll("div.d-codebyte").forEach((div) => {
-      const codebyteFrame = renderCodebyteFrame(div.dataset.language, div.textContent.trim());
+    elem.querySelectorAll("div.d-codebyte").forEach( async (div) => {
+      const codebyteFrame = await renderCodebyteFrame(div.dataset.language, div.textContent.trim());
       div.innerHTML = '';
       div.appendChild(codebyteFrame);
 
@@ -72,12 +76,6 @@ export default {
   name: "code-bytes",
 
   initialize() {
-    withPluginApi("0.8.31", (api) => {
-      loadScript(
-        "https://cdn.jsdelivr.net/npm/js-base64@3.6.0/base64.min.js"
-      ).then(() => {
-        return initializeCodeByte(api);
-      });
-    });
+    withPluginApi("0.8.31", initializeCodeByte);
   },
 };


### PR DESCRIPTION
## Overview
Fixing a bug where the plugin wouldn't run depending on how the page was loaded. Call `loadScript` only when needed, rather than before initializing the whole plugin.

### PR Checklist
- [ ] Related to JIRA ticket: ABC-123
- [X] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Testing Instructions
1. Visit http://localhost:3000
2. Click on an existing topic that contains codebytes
3. The codebytes render correctly
4. Refresh the page or open the url in a new tab. (This seems redundant, but this is how to reproduce the bug that was happening before).
5. The codebytes still render correctly when the page is reloaded.
