### PR TITLE
Add `clipboard-write` to iframe allow list

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -75,6 +75,7 @@ function initializeCodeByte(api) {
       const frame = document.createElement('iframe');
 
       const encodedURI = Base64.encodeURI(code);
+      frame.allow = "clipboard-write";
       frame.src = `http://localhost:8000/codebyte-editor?lang=${language}&code=${encodedURI}`;
 
       Object.assign(frame.style, {


### PR DESCRIPTION
## Overview
Companion PR for: https://github.com/codecademy-engineering/static-sites/pull/695

### PR Checklist
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
Not sure where we should remove the event listener for onCopy.

![9665e82f-098d-4a4a-91c5-40899a6b4556](https://user-images.githubusercontent.com/17210163/112532451-371de080-8d7f-11eb-8d2b-5760aeea5077.gif)


### Testing Instructions
1. See https://github.com/codecademy-engineering/static-sites/pull/695 for instructions
