### PR TITLE
Place CodeByte Toolbar Button in it's own group

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -1,15 +1,24 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import loadScript from "discourse/lib/load-script";
 
+const createCodecademyToolBarGroup = (toolbar) => {
+  toolbar.groups.lastObject.lastGroup = false;
+
+  toolbar.groups.addObject({ group: 'codecademy', buttons: [], lastGroup: true });
+
+  toolbar.addButton({
+    id: "codebyte",
+    title: "composer.codebyte",
+    group: "codecademy",
+    icon: "codecademy-logo",
+    className: "codecademy-codebyte-discourse-btn",
+    action: () => toolbar.context.send("insertCodeByte"),
+  });
+}
+
 function initializeCodeByte(api) {
   api.onToolbarCreate((toolbar) => {
-    toolbar.addButton({
-      title: "CodeBytes",
-      id: "codebyte",
-      group: "insertions",
-      icon: "codecademy-logo",
-      action: () => toolbar.context.send("insertCodeByte"),
-    });
+    createCodecademyToolBarGroup(toolbar);
 
     const onSaveResponse = (message) => {
       if (toolbar.context.isDestroyed || toolbar.context.isDestroying) {
@@ -104,7 +113,7 @@ function initializeCodeByte(api) {
         div.appendChild(saveButton);
       }
     });
-  });
+  }), {id: 'codebyte-preview'};
 }
 
 export default {

--- a/assets/stylesheets/common/code-bytes.scss
+++ b/assets/stylesheets/common/code-bytes.scss
@@ -1,2 +1,6 @@
 .code-bytes {
 }
+
+.codecademy-codebyte-discourse-btn {
+  flex-grow: 1;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,3 +1,5 @@
 en:
   js:
     code_bytes:
+    composer:
+      codebyte: "Create a Codebyte"


### PR DESCRIPTION
## Overview

- Defines `createCodecademyToolBarGroup` to contain the logic of creating this new Toolbar group and adding the CodeByte button. `onToolBarCreate` then calls this new function for setup.

- Adds a style for `codecademy-codebyte-discourse-btn` that will have the button be `flex-grow: 1` so it'll take up all empty space when available.

- Adds `Create a Codebyte` to the localization .yml files. So the text no longer says `en.CodeByte` for English setting users.

### PR Checklist
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
I had pushed this straight to main before this 🙈 
<img width="374" alt="Screen Shot 2021-03-26 at 10 28 48 AM" src="https://user-images.githubusercontent.com/17210163/112647362-d0500400-8e1e-11eb-805e-b085bfa4fb8d.png">

<img width="525" alt="Screen Shot 2021-03-26 at 10 20 33 AM" src="https://user-images.githubusercontent.com/17210163/112648012-756adc80-8e1f-11eb-9842-e618a5fb37f7.png">
<img width="309" alt="Screen Shot 2021-03-26 at 10 21 22 AM" src="https://user-images.githubusercontent.com/17210163/112648013-756adc80-8e1f-11eb-9bda-61983dbe8031.png">



### Testing Instructions
1. Run locally
2. Try making some CodeBytes
