### PR TITLE
save to post on language select

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -22,11 +22,11 @@ function initializeCodeByte(api) {
       this._super(...arguments);
 
       this.onSaveResponse = (message) => {
-        const editableCodebytes = Array.from(
-          this.element.querySelectorAll('.d-editor-preview .d-codebyte iframe')
-        ).map((frame) => frame.contentWindow);
-
         if (message.data.codeByteSaveResponse) {
+          const editableCodebytes = Array.from(
+            this.element.querySelectorAll('.d-editor-preview .d-codebyte iframe')
+          ).map((frame) => frame.contentWindow);
+
           const index = editableCodebytes.indexOf(message.source);
           if (index >= 0) {
             this.send("updateCodeByte", index, message.data.codeByteSaveResponse);


### PR DESCRIPTION
  
<!---
READ THIS: Please review the Pre-Review Checklist before seeking review! https://www.notion.so/codecademy/Development-Process-0e566d88c7734561b63f45313a9c40bd
-->

## Overview
static-sites companion: https://github.com/codecademy-engineering/static-sites/pull/704

Instead of using an `id` to identify which iframe a save message comes from (which only works when the cycle originates from the plugin, which is not the case for any kind of autosave), we now keep a list of the current editable codebyte iframes and compare them to `message.source`.

Some minor QOL improvements as well:
- standardize `code` and `text` variable names to just `text` (100% my fault, everything was named `text` until I came along). I don't have a preference between the two but I do think we should just use one or the other
- rename `codeBytesSaveRequested` and `codeBytesSaveResponse` to `codeByteSaveRequest` and `codeByteSaveResponse` for better parallelism

### PR Checklist
- [x] Related to JIRA ticket: [REACH-782](https://codecademy.atlassian.net/browse/REACH-782)
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
made u look 🤣 

### Testing Instructions
1. run discourse locally, along with [this static-sites branch](https://github.com/codecademy-engineering/static-sites/pull/704)
2. create a topic with multiple codebytes
3. select languages in both and see that they autosave correctly
4. edit both and click "save to post" and see that they save correctly
5. post topic and see that everything looks dandy
6. edit topic and make sure all the saving still works correctly
