### PR TITLE
Toolbar: Use CSS to show visual users the button title too

### DIFF
--- a/assets/stylesheets/common/code-bytes.scss
+++ b/assets/stylesheets/common/code-bytes.scss
@@ -9,13 +9,14 @@
 }
 
 .d-icon.d-icon-codecademy-logo.svg-icon.svg-string {
-  height: 30px;
+  height: 15px;
   width: 28px;
-  padding: 0 0.5em;
+  padding: 7.5px 0.5em;
 }
 
 .codecademy-codebyte-discourse-btn::after {
   content: 'Create a Codebyte';
   font-weight: bold;
   word-break: break-all;
+  padding-top: 0.25em;
 }


### PR DESCRIPTION
## Overview
Currently, the Codebyte toolbar button contains the title attribute "Create a Codebyte".
Using CSS, this PR displays "Create a Codebyte" as a psuedo-element (see notes) after the Codecademy icon when enough positive space is available.

![localhost_3000_ (1)](https://user-images.githubusercontent.com/17210163/113716168-4b83a680-96b8-11eb-879e-097db903ed22.png)


### PR Checklist
- [x] Related to JIRA ticket: REACH-716
- [x] I have run this code to verify it works
- [x] Signed off from Li
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes

### On psuedo-element and accessibility:
> CSS pseudo element content, either :before or :after , must only be used for decorative purposes.
The `title` attribute already contains that information. We're just showing it for visual readers now.

(Aria-label perhaps would be better, but Discourse currently doesn't have that for their default buttons on prod)

<img width="500" alt="Screen Shot 2021-04-06 at 8 52 05 AM" src="https://user-images.githubusercontent.com/17210163/113713888-d616d680-96b5-11eb-9238-c8e68b70a835.png">

Related topic: [Discourse with a screen reader](https://meta.discourse.org/t/discourse-with-a-screen-reader/178105)

### Demo

#### Safari
![codebyte_btn_safari](https://user-images.githubusercontent.com/17210163/113713094-ebd7cc00-96b4-11eb-8c89-68de534b4deb.gif)


#### Firefox
![codebyte_btn_firefox](https://user-images.githubusercontent.com/17210163/113713138-f8f4bb00-96b4-11eb-8916-252ae3466a68.gif)


#### Chrome (with official theme)
![3464d520-a160-49ac-b14c-db43cf142cc1](https://user-images.githubusercontent.com/17210163/113716214-5a6a5900-96b8-11eb-852c-9982db0c8b2d.gif)



### Testing Instructions
1. Visit Discourse and make or edit a post to bring up the post editor!
2. Check out Toolbar, increasing and decreasing window size and also zoom in/out size.
