### PR TITLE
Point iframe at production instead of localhost

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -95,7 +95,7 @@ function initializeCodeByte(api) {
 
       const encodedURI = Base64.encodeURI(text);
       frame.allow = "clipboard-write";
-      frame.src = `http://localhost:8000/codebyte-editor?lang=${language}&text=${encodedURI}`;
+      frame.src = `https://www.codecademy.com/codebyte-editor?lang=${language}&text=${encodedURI}`;
 
       Object.assign(frame.style, {
         display: 'block',


### PR DESCRIPTION
## Overview
Point the Codebytes iframe at production instead of localhost. Getting ready for deploying the plugin for real!

### PR Checklist
- [x] Related to JIRA ticket: REACH-857
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
If you're developing locally and want to point this back at your local instance, you would just need to modify this line again. This is just a quick fix to get this ready to go to production. It might be possible to have the URL in a site setting. If this becomes annoying for local development, we can look into that solution.

### Testing Instructions
1. Run Discourse locally. Don't run static sites locally!
2. Create a new post or reply.
3. Hit the "Create a Codebyte" button
4. The Codebyte editor appears!
5. You can inspect the element and see that the iframe src is https://www.codecademy.com/codebyte-editor
6. Run some code, get the output, and rejoice.