### PR TITLE
Remove placeholder text

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js.es6
+++ b/assets/javascripts/initializers/code-bytes.js.es6
@@ -44,7 +44,7 @@ function initializeCodeByte(api) {
 
     actions: {
       insertCodeByte() {
-        let exampleFormat = '[codebyte]\nhello world\n[/codebyte]'
+        let exampleFormat = '[codebyte]\n\n[/codebyte]'
         let startTag = '[codebyte]\n'
         let endTag = '\n[/codebyte]'
         const lineValueSelection = this._getSelected("", {lineVal:true})


### PR DESCRIPTION
## Overview
From the placeholder text when adding a new codebyte. Previously it had the plain text "hello world". This is needed so in the future we can have better boilerplate code per language.

### PR Checklist
- [x] Related to JIRA ticket: REACH-902
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Testing Instructions
1. Click the "Create a Codebyte" button
2. [codebyte] tags are created with nothing in between.
![Screen Shot 2021-04-19 at 3 43 29 PM](https://user-images.githubusercontent.com/4821431/115293964-ff0f8080-a125-11eb-9f8b-c28cf81c2f09.png)

