### PR TITLE
Add more acceptance tests

### DIFF
--- a/test/javascripts/acceptance/codebytes-test.js
+++ b/test/javascripts/acceptance/codebytes-test.js
@@ -1,9 +1,50 @@
 import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
-import { settled } from "@ember/test-helpers";
 
 acceptance("CodeBytes", function (needs) {
   needs.user();
   needs.settings({ code_bytes_enabled: true });
+
+  test("it inserts a codebyte when the Create a Codebyte composer toolbar button is clicked", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    
+    await click(".d-editor button.codecademy-codebyte-discourse-btn");
+    assert.equal(
+      queryAll(".d-editor-input").val(),
+      '[codebyte]\n\n[/codebyte]\n',
+      "it inserts a blank codebyte when no text is selected"
+    );
+
+    await fillIn(
+      ".d-editor-input",
+      'print("Hello, world!")'
+    );
+    const textarea = queryAll(".d-editor-input")[0];
+    textarea.selectionStart = 0;
+    textarea.selectionEnd = textarea.value.length;
+    await click(".d-editor button.codecademy-codebyte-discourse-btn");
+    assert.equal(
+      queryAll(".d-editor-input").val(),
+      '[codebyte]\nprint("Hello, world!")\n[/codebyte]\n',
+      "it wraps selected text in a [codebyte] tag"
+    );
+  });
+
+  test("it renders an iframe in the preview area", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    
+    await fillIn(
+      ".d-editor-input",
+      '[codebyte]\n\n[/codebyte]'
+    );
+
+    assert.equal(
+      queryAll(".d-editor-preview .d-codebyte iframe").attr('src'),
+      "https://www.codecademy.com/codebyte-editor?lang=&text=",
+      "it renders an iframe pointing to the codebyte editor on codecademy.com"
+    );
+  });
 
   test("it updates the markdown when the iframe sends a save response message", async function (assert) {
     await visit("/");


### PR DESCRIPTION
## Overview
Add acceptance tests for the toolbar button and for rendering the markdown into an iframe.

### PR Checklist
- [X] Related to JIRA ticket: [REACH-965](https://codecademy.atlassian.net/browse/REACH-965)
- [X] I have run this code to verify it works
- [X] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
Let me know any other tests that we should add!

### Testing Instructions
1. Run `rake plugin:qunit['CodeBytes']` in the Discourse directory
2. Confirm that all tests pass
![Screen Shot 2021-05-03 at 6 38 34 PM](https://user-images.githubusercontent.com/4821431/116942017-c51e9e00-ac3e-11eb-9451-18487414a539.png)

