### PR TITLE
add margin to codebyte editor and save button

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -126,6 +126,7 @@ function initializeCodeByte(api) {
         height: '400px',
         width: '100%',
         maxWidth: '712px',
+        marginBottom: '24px',
         border: 0,
       });
 
@@ -146,7 +147,7 @@ function initializeCodeByte(api) {
         const saveButton = document.createElement('button');
         saveButton.className = 'btn-primary';
         saveButton.textContent = 'Save to post';
-        saveButton.style.marginTop = '24px';
+        saveButton.style.marginBottom = '24px';
         saveButton.onclick = () =>
           codebyteFrame.contentWindow.postMessage(
             { codeByteSaveRequest: true },


### PR DESCRIPTION
  
<!---
READ THIS: Please review the Pre-Review Checklist before seeking review! https://www.notion.so/codecademy/Development-Process-0e566d88c7734561b63f45313a9c40bd
-->

## Overview
ezpz

### PR Checklist
- [x] Related to JIRA ticket: [REACH-1007(https://codecademy.atlassian.net/browse/REACH-1007)
- [x] I have run this code to verify it works
- [ ] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
there will be an extra margin at the bottom of the post if it ends with a codebyte, but it looks fine imo

in editor:
<img width="1465" alt="Screen Shot 2021-05-21 at 3 26 26 PM" src="https://user-images.githubusercontent.com/19958143/119188831-3afd7480-ba49-11eb-93b4-bf11c7a4f35d.png">

in topic:
<img width="776" alt="Screen Shot 2021-05-21 at 3 25 48 PM" src="https://user-images.githubusercontent.com/19958143/119188844-405abf00-ba49-11eb-83eb-3bc86d0f604d.png">

### Testing Instructions
1. run discourse locally with this branch
2. make a post with two codebytes and no space between them
3. see that there's space between the save button and the next codebyte in the editor
4. publish the post and see that there's space between the first codebyte and the second codebyte
