### PR TITLE
Add language validation on save

### DIFF
--- a/assets/javascripts/discourse/templates/modal/invalid-codebyte-modal.hbs
+++ b/assets/javascripts/discourse/templates/modal/invalid-codebyte-modal.hbs
@@ -1,0 +1,9 @@
+{{#d-modal-body title="modal.title"}}
+  <div>{{i18n "modal.content"}}</div>
+  <div class="action-buttons">
+    {{d-button
+      action=(action "goBackAndFix")
+      label="modal.button"
+    }}
+  </div>
+{{/d-modal-body}}

--- a/assets/javascripts/discourse/templates/modal/invalid-codebyte-modal.hbs
+++ b/assets/javascripts/discourse/templates/modal/invalid-codebyte-modal.hbs
@@ -1,9 +1,10 @@
 {{#d-modal-body title="modal.title"}}
   <div>{{i18n "modal.content"}}</div>
-  <div class="action-buttons">
+  <div>
     {{d-button
       action=(action "goBackAndFix")
       label="modal.button"
+      class="btn-primary"
     }}
   </div>
 {{/d-modal-body}}

--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -2,15 +2,19 @@ import loadScript from 'discourse/lib/load-script';
 import { withPluginApi } from 'discourse/lib/plugin-api';
 import showModal from "discourse/lib/show-modal";
 
+export const CODEBYTE_OPEN_TAG_REGEX = /^\[codebyte([ ]+language=([^\s]*?))?[ ]*]$/
+export const CODEBYTE_OPEN_TAG_WITH_LANG_REGEX = /^\[codebyte[ ]+language=([^\s]*?)[ ]*]$/
+export const CODEBYTE_CLOSE_TAG_REGEX = /^\[\/codebyte]$/
+
 export function findCodeByte(lines = [], index) {
   const startTagLines = [];
   const range = [];
   let matchIndex = -1;
 
   lines.some((line, lineNumber) => {
-    if (line.match(/^\[codebyte([ ]+language=([^\s]*?))?[ ]*]$/)) {
+    if (line.match(CODEBYTE_OPEN_REGEX)) {
       startTagLines.push(lineNumber);
-    } else if (line.match(/^\[\/codebyte]$/) && startTagLines.length) {
+    } else if (line.match(CODEBYTE_CLOSE_TAG_REGEX) && startTagLines.length) {
       const start = startTagLines.pop();
       if (startTagLines.length === 0) {
         matchIndex++
@@ -189,7 +193,7 @@ function initializeCodeByte(api) {
       do {
         [start, end] = findCodeByte(inputLines, index);
         index++;
-        if (start !== undefined && !inputLines[start].match(/^\[codebyte[ ]+language=([^\s]*?)[ ]*]$/)) {
+        if (start !== undefined && !inputLines[start].match(CODEBYTE_OPEN_TAG_WITH_LANG_REGEX)) {
           allCodebytesAreValid = false;
         }
       } while (allCodebytesAreValid && start !== undefined)

--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -12,7 +12,7 @@ export function findCodeByte(lines = [], index) {
   let matchIndex = -1;
 
   lines.some((line, lineNumber) => {
-    if (line.match(CODEBYTE_OPEN_REGEX)) {
+    if (line.match(CODEBYTE_OPEN_TAG_REGEX)) {
       startTagLines.push(lineNumber);
     } else if (line.match(CODEBYTE_CLOSE_TAG_REGEX) && startTagLines.length) {
       const start = startTagLines.pop();

--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -2,7 +2,7 @@ import loadScript from 'discourse/lib/load-script';
 import { withPluginApi } from 'discourse/lib/plugin-api';
 import showModal from "discourse/lib/show-modal";
 
-export const CODEBYTE_OPEN_TAG_REGEX = /^\[codebyte([ ]+language=([^\s]*?))?[ ]*]$/
+export const CODEBYTE_OPEN_TAG_REGEX = /^\[codebyte.*]$/
 export const CODEBYTE_OPEN_TAG_WITH_LANG_REGEX = /^\[codebyte[ ]+language=([^\s]+?)[ ]*]$/
 export const CODEBYTE_CLOSE_TAG_REGEX = /^\[\/codebyte]$/
 

--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -3,7 +3,7 @@ import { withPluginApi } from 'discourse/lib/plugin-api';
 import showModal from "discourse/lib/show-modal";
 
 export const CODEBYTE_OPEN_TAG_REGEX = /^\[codebyte([ ]+language=([^\s]*?))?[ ]*]$/
-export const CODEBYTE_OPEN_TAG_WITH_LANG_REGEX = /^\[codebyte[ ]+language=([^\s]*?)[ ]*]$/
+export const CODEBYTE_OPEN_TAG_WITH_LANG_REGEX = /^\[codebyte[ ]+language=([^\s]+?)[ ]*]$/
 export const CODEBYTE_CLOSE_TAG_REGEX = /^\[\/codebyte]$/
 
 export function findCodeByte(lines = [], index) {

--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -196,7 +196,8 @@ function initializeCodeByte(api) {
 
       if (!allCodebytesAreValid) {
         const warningModal = showModal("invalidCodebyteModal", {
-          model: this.model
+          model: this.model,
+          modalClass: "codebytes-invalid-modal"
         });
         warningModal.actions.goBackAndFix = () =>
           this.send("closeModal");

--- a/assets/stylesheets/common/code-bytes.scss
+++ b/assets/stylesheets/common/code-bytes.scss
@@ -20,3 +20,9 @@
   word-break: break-all;
   padding-top: 0.25em;
 }
+
+.codebytes-invalid-modal .btn-primary {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 16px;
+}

--- a/assets/stylesheets/common/code-bytes.scss
+++ b/assets/stylesheets/common/code-bytes.scss
@@ -26,3 +26,7 @@
   justify-content: space-between;
   margin-top: 16px;
 }
+
+.codebytes-invalid-modal .modal-header .modal-close {
+  padding-left: 0;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,5 +1,8 @@
 en:
   js:
-    code_bytes:
     composer:
       codebyte: "Create a Codebyte"
+    modal:
+      title: "Please select a language"
+      content: "Your post includes one or more Codebytes that are missing the language attribute."
+      button: "Ok"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,5 +4,5 @@ en:
       codebyte: "Create a Codebyte"
     modal:
       title: "Please select a language"
-      content: "Your post includes one or more Codebytes that are missing the language attribute."
+      content: "Your post includes one or more Codebytes that has no language selected. You can select a language for each Codebyte in the preview panel on the right."
       button: "Ok"

--- a/test/javascripts/unit/codebytes.test.js
+++ b/test/javascripts/unit/codebytes.test.js
@@ -91,13 +91,11 @@ describe('findCodeByte', () => {
     expect(findCodeByte(testString, 1)).toEqual([]);
   });
 
-  it('ignores codebytes with non-language attributes', () => {
+  it('ignores codebytes with an open tag spread across multiple lines', () => {
     const testString = [
-      '[codebyte lang=javascript]',
-      '[/codebyte]',
-      '[codebyte lang=javascript language=javascript]',
-      '[/codebyte]',
-      '[codebyte language=javascript lang=javascript]',
+      '[codebyte ',
+      'language=javascript]',
+      'console.log()',
       '[/codebyte]',
     ];
 

--- a/test/javascripts/unit/codebytes.test.js
+++ b/test/javascripts/unit/codebytes.test.js
@@ -2,6 +2,7 @@ import { findCodeByte } from '../../../assets/javascripts/initializers/code-byte
 
 jest.mock('discourse/lib/plugin-api', () => {}, { virtual: true });
 jest.mock('discourse/lib/load-script', () => {}, { virtual: true });
+jest.mock('discourse/lib/show-modal', () => {}, { virtual: true });
 
 describe('findCodeByte', () => {
   it('finds empty codebytes at a given index', () => {
@@ -92,8 +93,6 @@ describe('findCodeByte', () => {
 
   it('ignores codebytes with non-language attributes', () => {
     const testString = [
-      '[codebyte ]',
-      '[/codebyte]',
       '[codebyte lang=javascript]',
       '[/codebyte]',
       '[codebyte lang=javascript language=javascript]',


### PR DESCRIPTION
## Overview
Adds a validation on save and a blocking modal to ensure that each CodeByte has the `language` attribute specified. We saw that users often type out the markdown for a CodeByte manually and forget this parameter, which makes it render incorrectly.

### PR Checklist
- [x] Related to JIRA ticket: REACH-1016
- [x] I have run this code to verify it works
- [x] This PR includes [client](https://www.notion.so/codecademy/Frontend-Unit-Tests-1cbf4e078a6647559b4583dfb6d3cb18), [server](https://www.notion.so/codecademy/Ruby-Unit-Tests-6f0353926a034df4909142e4fe686bf7), and/or [end to end](https://www.notion.so/codecademy/Frontend-Acceptance-Tests-cb1125a99a6c4d478a85979aa46cad03) tests for the code change

### Notes
It checks that there is a language specified, not that it's a valid language. I think it's better to have the embedded editor itself determine the valid list of languages, rather than the Discourse plugin.

### Testing Instructions
1. Create a new topic or a reply
2. Insert a blank CodeByte with the button.
3. Without selecting a language in the preview pane, try to submit the post.
4. You should be blocked from saving and see a popup window.
5. Select a language and allow it to update the left editor.
6. Attempt to submit again. This time, it should be posted successfully.

From the Discourse repo: `rake plugin:qunit['CodeBytes']`

From this repo: `yarn test`

![Screen Shot 2021-06-11 at 7 46 19 PM](https://user-images.githubusercontent.com/4821431/121758598-fddc4d80-caef-11eb-83dd-32985d542d26.png)