### PR TITLE
Fix broken test

### DIFF
--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -55,13 +55,19 @@ function initializeCodeByte(api) {
 
       this.onSaveResponse = (message) => {
         if (message.data.codeByteSaveResponse) {
-          const editableCodebytes = Array.from(
-            this.element?.querySelectorAll(
-              '.d-editor-preview .d-codebyte iframe'
-            )
+          const editableCodebyteFrames = this.element?.querySelectorAll(
+            '.d-editor-preview .d-codebyte iframe'
+          );
+
+          if (!editableCodebyteFrames) {
+            return;
+          }
+
+          const codebyteWindows = Array.from(
+            editableCodebyteFrames
           ).map((frame) => frame.contentWindow);
 
-          const index = editableCodebytes.indexOf(message.source);
+          const index = codebyteWindows.indexOf(message.source);
           if (index >= 0) {
             this.send(
               'updateCodeByte',

--- a/assets/javascripts/initializers/code-bytes.js
+++ b/assets/javascripts/initializers/code-bytes.js
@@ -56,7 +56,7 @@ function initializeCodeByte(api) {
       this.onSaveResponse = (message) => {
         if (message.data.codeByteSaveResponse) {
           const editableCodebytes = Array.from(
-            this.element.querySelectorAll(
+            this.element?.querySelectorAll(
               '.d-editor-preview .d-codebyte iframe'
             )
           ).map((frame) => frame.contentWindow);

--- a/test/javascripts/acceptance/codebytes-test.js
+++ b/test/javascripts/acceptance/codebytes-test.js
@@ -4,6 +4,8 @@ import {
   queryAll,
   visible 
 } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { click, currentURL, fillIn, triggerEvent, visit } from "@ember/test-helpers";
 
 acceptance("CodeBytes", function (needs) {
   needs.user();

--- a/test/javascripts/acceptance/codebytes-test.js
+++ b/test/javascripts/acceptance/codebytes-test.js
@@ -44,9 +44,8 @@ acceptance("CodeBytes", function (needs) {
       '[codebyte]\n\n[/codebyte]'
     );
 
-    assert.equal(
-      queryAll(".d-editor-preview .d-codebyte iframe").attr('src'),
-      "https://www.codecademy.com/codebyte-editor?lang=&text=",
+    assert.ok(
+      queryAll(".d-editor-preview .d-codebyte iframe").attr('src').startsWith("https://www.codecademy.com/codebyte-editor"),
       "it renders an iframe pointing to the codebyte editor on codecademy.com"
     );
   });


### PR DESCRIPTION
This test started failing at some point when we added additional URL params to the iframe. I changed it to check the start of the URL, not a strict match.

Other parts of the test also broke with the latest version of Discourse. Some test helpers that used to be available automatically now need to be explicitly imported. There were also intermittent test failures with variables being null or undefined. I think this only happens in the test environment due to race conditions of multiple tests, as they always went away when I ran just a single test case at a time. Anyway, I added some checks for null values.

Related JIRA ticket: https://codecademy.atlassian.net/browse/DISC-617

### Testing instructions
1. Pull the latest code for the discourse repo (Discourse itself, not the plugin).
2. Run the discourse backend `rails s`
3. Run the discourse frontend `bin/ember-cli`
4. To run the automated tests, visit http://localhost:4200/tests?qunit_single_plugin=CodeBytes&qunit_skip_core=1. Verify that everything passes.
5. Also perform manual tests to confirm that the non-test code changes didn't break anything:
6. Visit http://localhost:4200/
7. Create a new topic
8. Click the "Create a Codebyte" button. Verify that valid markdown syntax is inserted and a codebyte appears in the preview window.
9. Select a language. Verify that the markdown in the editor pane is updated.
10. Make some changes in the codebyte in the preview pane and click the "Save to post" button. Verify that the markdown in the editor pane is updated.